### PR TITLE
Add developers page linking to source code, docs, and open austin

### DIFF
--- a/components/scrapd-developers-view/component.js
+++ b/components/scrapd-developers-view/component.js
@@ -2,13 +2,147 @@ import Proptypes from 'prop-types';
 import styled from '@emotion/styled';
 import dynamic from 'next/dynamic';
 
+
+const headerStyle = {
+  height: '80vh',
+  'background-image': 'url("https://wallpaperstudio10.com/static/wpdb/wallpapers/1920x1080/177348.jpg")',
+};
+
+const titleStyle = {
+  'background-color': '#1890ff',
+  'font-size': '10vh',
+  'width': 'auto',
+  'text-align': 'center',
+}
+
+const positionStyle = {
+   top: "50%",
+   left: "50%",
+   transform: "translate(-50%, -10%)",
+   'position': 'absolute',
+   'width': '100%'
+}
+const subtitleStyle = {
+  ...titleStyle,
+  'font-size': '3vh',
+  'padding': '5px'
+}
+
+const smallSubtitleStyle = {
+  ...subtitleStyle,
+  'font-size': '2.5vh',
+}
+
+const hstyle = {
+  'text-align': 'center'
+}
+
+const sectionStyle = {
+  'border': 'medium solid gray',
+  'border-radius': '20px'
+}
+
+const sectionTitle = {
+  'text-align':'center',
+  'transform':'translate(0, -50%)',
+}
+
+const sectionTitleStyle = {
+  'background-color': 'white',
+  'padding': '10px'
+}
+
+const contributionSection = {
+  'padding': '30px',
+  'padding-top': '5px'
+}
+
+const section = {
+  'width': '75%',
+  'display': 'inline-block',
+  'padding-left': '5%',
+  'float':'bottom',
+  'overflow':'hidden',
+  'vertical-align':'middle'
+}
+
+const imgStyle = {
+  'float':'inline-start',
+  'width': '25%'
+}
+
 const ScrapdDeveloperView = ({ fatalities }) => {
   return (
     <div>
-        <h3>Scrapd has documentation available at this link: <a href="https://docs.scrapd.org">Docs</a>.</h3>
-        <h3>Scrapd is open-source. You can find the scraping tool we use to retrieve data at this link: <a href="https://github.com/scrapd/scrapd">Scraper Source</a>.</h3>
-        <h1>You can also find the source code for this site at this link: <a href="https://github.com/scrapdviz/scrapdviz">Visualization Source</a>.</h1>
-        <h3>ScrAPD is a project of Open Austin, a Code for America brigade. You can find more data about the organization at this link: <a href="https://open-austin.org">Open Austin</a>.</h3>
+      <div style={headerStyle}>
+        <div style={positionStyle}>
+          <h1 style={hstyle}><span style={titleStyle}>ScrAPD</span></h1>
+          <h2 style={hstyle}><span style={subtitleStyle}>Safety data, collected automatically for you</span></h2>
+          <h3 style={hstyle}><span style={smallSubtitleStyle}>ScrAPD scrapes the web for traffic fatality data, making it accessible to all</span></h3>
+        </div>
+      </div>
+      &nbsp;
+      <div style={sectionStyle}>
+        <h1 style={sectionTitle}><span style={sectionTitleStyle}>What is ScrAPD?</span></h1>
+        <div style={contributionSection}>
+          <div style={section}>
+            <h3>ScrAPD is a collection of tools to automatically collect information about traffic fatalities in the city of Austin, TX and render it on a modern dashboard.</h3>
+            &nbsp;
+            <h3>Visit our documentation page to learn more about what ScrAPD does, how it works, and who it's helping today.</h3>
+          </div>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%'/>
+        </div>
+      </div>
+      &nbsp;
+      <div style={sectionStyle}>
+        <h1 style={sectionTitle}><span style={sectionTitleStyle}>How do I view the data?</span></h1>
+        <div style={contributionSection}>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%' />
+          <div style={section}>
+            <h3>Spreadsheets can be difficult to understand. ScrAPDViz solves this problem.</h3>
+            &nbsp;
+            <h3>Charts, graphs, and other data visualizations help ScrAPDViz simplify large datasets into a format anyone can understand.</h3>
+          </div>
+        </div>
+      </div>
+      &nbsp;
+      <div style={sectionStyle}>
+        <h1 style={sectionTitle}><span style={sectionTitleStyle}>How does ScrAPD work?</span></h1>
+        <div style={contributionSection}>
+          <div style={section}>
+            <h3>[Info about the tool]</h3>
+            &nbsp;
+            <h3>Visit our documentation page on the ScrAPD scraper and try it yourself!</h3>
+          </div>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%'/>
+        </div>
+      </div>
+      &nbsp;
+      <div style={sectionStyle}>
+        <h1 style={sectionTitle}><span style={sectionTitleStyle}>How do I grab ALL the data?</span></h1>
+        <div style={contributionSection}>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%' />
+          <div style={section}>
+            <h3>[Info about the data.world]</h3>
+            &nbsp;
+            <h3>[more]</h3>
+          </div>
+        </div>
+      </div>
+      &nbsp;
+      <div style={sectionStyle}>
+        <h1 style={sectionTitle}><span style={sectionTitleStyle}>What if I want to contribute?</span></h1> 
+        <div style={contributionSection}>
+          <div style={section}>
+            <h3>Scrapd has documentation available at this link: <a href="https://docs.scrapd.org">Docs</a>.</h3>
+            <h3>Scrapd is open-source. You can find the scraping tool we use to retrieve data at this link: <a href="https://github.com/scrapd/scrapd">Scraper Source</a>.</h3>
+            <h1>You can also find the source code for this site at this link: <a href="https://github.com/scrapdviz/scrapdviz">Visualization Source</a>.</h1>
+            <h3>ScrAPD is a project of Open Austin, a Code for America brigade. You can find more data about the organization at this link: <a href="https://open-austin.org">Open Austin</a>.</h3>
+          </div>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%' />     
+        </div>
+      </div>
+
     </div>
   );
 };

--- a/components/scrapd-developers-view/component.js
+++ b/components/scrapd-developers-view/component.js
@@ -1,127 +1,154 @@
-import Proptypes from 'prop-types';
-import styled from '@emotion/styled';
-import dynamic from 'next/dynamic';
-
-
 const headerStyle = {
   height: '80vh',
-  'background-image': 'url("https://wallpaperstudio10.com/static/wpdb/wallpapers/1920x1080/177348.jpg")',
+  'background-image': 'url("https://wallpaperstudio10.com/static/wpdb/wallpapers/1920x1080/177348.jpg")'
 };
 
 const titleStyle = {
   'background-color': '#1890ff',
   'font-size': '10vh',
-  'width': 'auto',
-  'text-align': 'center',
-}
+  width: 'auto',
+  'text-align': 'center'
+};
 
 const positionStyle = {
-   top: "50%",
-   left: "50%",
-   transform: "translate(-50%, -10%)",
-   'position': 'absolute',
-   'width': '100%'
-}
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -10%)',
+  position: 'absolute',
+  width: '100%'
+};
 const subtitleStyle = {
   ...titleStyle,
   'font-size': '3vh',
-  'padding': '5px'
-}
+  padding: '5px'
+};
 
 const smallSubtitleStyle = {
   ...subtitleStyle,
-  'font-size': '2.5vh',
-}
+  'font-size': '2.5vh'
+};
 
 const hstyle = {
   'text-align': 'center'
-}
+};
 
 const sectionStyle = {
-  'border': 'medium solid gray',
+  border: 'medium solid gray',
   'border-radius': '20px'
-}
+};
 
 const sectionTitle = {
-  'text-align':'center',
-  'transform':'translate(0, -50%)',
-}
+  'text-align': 'center',
+  transform: 'translate(0, -50%)'
+};
 
 const sectionTitleStyle = {
   'background-color': 'white',
-  'padding': '10px'
-}
+  padding: '10px'
+};
 
 const contributionSection = {
-  'padding': '30px',
+  padding: '30px',
   'padding-top': '5px'
-}
+};
 
 const section = {
-  'width': '75%',
-  'display': 'inline-block',
+  width: '75%',
+  display: 'inline-block',
   'padding-left': '5%',
-  'float':'bottom',
-  'overflow':'hidden',
-  'vertical-align':'middle'
-}
+  float: 'bottom',
+  overflow: 'hidden',
+  'vertical-align': 'middle'
+};
 
-const imgStyle = {
-  'float':'inline-start',
-  'width': '25%'
-}
-
-const ScrapdDeveloperView = ({ fatalities }) => {
+const ScrapdDeveloperView = () => {
   return (
     <div>
       <div style={headerStyle}>
         <div style={positionStyle}>
-          <h1 style={hstyle}><span style={titleStyle}>ScrAPD</span></h1>
-          <h2 style={hstyle}><span style={subtitleStyle}>Safety data, collected automatically for you</span></h2>
-          <h3 style={hstyle}><span style={smallSubtitleStyle}>ScrAPD scrapes the web for traffic fatality data, making it accessible to all</span></h3>
+          <h1 style={hstyle}>
+            <span style={titleStyle}>ScrAPD</span>
+          </h1>
+          <h2 style={hstyle}>
+            <span style={subtitleStyle}>Safety data, collected automatically for you</span>
+          </h2>
+          <h3 style={hstyle}>
+            <span style={smallSubtitleStyle}>
+              ScrAPD scrapes the web for traffic fatality data, making it accessible to all
+            </span>
+          </h3>
         </div>
       </div>
       &nbsp;
       <div style={sectionStyle}>
-        <h1 style={sectionTitle}><span style={sectionTitleStyle}>What is ScrAPD?</span></h1>
+        <h1 style={sectionTitle}>
+          <span style={sectionTitleStyle}>What is ScrAPD?</span>
+        </h1>
         <div style={contributionSection}>
           <div style={section}>
-            <h3>ScrAPD is a collection of tools to automatically collect information about traffic fatalities in the city of Austin, TX and render it on a modern dashboard.</h3>
+            <h3>
+              ScrAPD is a collection of tools to automatically collect information about traffic fatalities in the city
+              of Austin, TX and render it on a modern dashboard.
+            </h3>
             &nbsp;
-            <h3>Visit our documentation page to learn more about what ScrAPD does, how it works, and who it's helping today.</h3>
+            <h3>
+              Visit our documentation page to learn more about what ScrAPD does, how it works, and who it&#39;s helping
+              today.
+            </h3>
           </div>
-          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%'/>
+          <img
+            src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png"
+            width="25%"
+          />
         </div>
       </div>
       &nbsp;
       <div style={sectionStyle}>
-        <h1 style={sectionTitle}><span style={sectionTitleStyle}>How do I view the data?</span></h1>
+        <h1 style={sectionTitle}>
+          <span style={sectionTitleStyle}>How do I view the data?</span>
+        </h1>
         <div style={contributionSection}>
-          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%' />
+          <img
+            src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png"
+            width="25%"
+          />
           <div style={section}>
             <h3>Spreadsheets can be difficult to understand. ScrAPDViz solves this problem.</h3>
             &nbsp;
-            <h3>Charts, graphs, and other data visualizations help ScrAPDViz simplify large datasets into a format anyone can understand.</h3>
+            <h3>
+              Charts, graphs, and other data visualizations help ScrAPDViz simplify large datasets into a format anyone
+              can understand.
+            </h3>
           </div>
         </div>
       </div>
       &nbsp;
       <div style={sectionStyle}>
-        <h1 style={sectionTitle}><span style={sectionTitleStyle}>How does ScrAPD work?</span></h1>
+        <h1 style={sectionTitle}>
+          <span style={sectionTitleStyle}>How does ScrAPD work?</span>
+        </h1>
         <div style={contributionSection}>
           <div style={section}>
             <h3>[Info about the tool]</h3>
             &nbsp;
             <h3>Visit our documentation page on the ScrAPD scraper and try it yourself!</h3>
           </div>
-          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%'/>
+          <img
+            src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png"
+            width="25%"
+          />
         </div>
       </div>
       &nbsp;
       <div style={sectionStyle}>
-        <h1 style={sectionTitle}><span style={sectionTitleStyle}>How do I grab ALL the data?</span></h1>
+        <h1 style={sectionTitle}>
+          <span style={sectionTitleStyle}>How do I grab ALL the data?</span>
+        </h1>
         <div style={contributionSection}>
-          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%' />
+          <img
+            src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png"
+            width="25%"
+          />
           <div style={section}>
             <h3>[Info about the data.world]</h3>
             &nbsp;
@@ -131,21 +158,35 @@ const ScrapdDeveloperView = ({ fatalities }) => {
       </div>
       &nbsp;
       <div style={sectionStyle}>
-        <h1 style={sectionTitle}><span style={sectionTitleStyle}>What if I want to contribute?</span></h1> 
+        <h1 style={sectionTitle}>
+          <span style={sectionTitleStyle}>What if I want to contribute?</span>
+        </h1>
         <div style={contributionSection}>
           <div style={section}>
-            <h3>Scrapd has documentation available at this link: <a href="https://docs.scrapd.org">Docs</a>.</h3>
-            <h3>Scrapd is open-source. You can find the scraping tool we use to retrieve data at this link: <a href="https://github.com/scrapd/scrapd">Scraper Source</a>.</h3>
-            <h1>You can also find the source code for this site at this link: <a href="https://github.com/scrapdviz/scrapdviz">Visualization Source</a>.</h1>
-            <h3>ScrAPD is a project of Open Austin, a Code for America brigade. You can find more data about the organization at this link: <a href="https://open-austin.org">Open Austin</a>.</h3>
+            <h3>
+              Scrapd has documentation available at this link: <a href="https://docs.scrapd.org">Docs</a>.
+            </h3>
+            <h3>
+              Scrapd is open-source. You can find the scraping tool we use to retrieve data at this link:
+              <a href="https://github.com/scrapd/scrapd">Scraper Source</a>.
+            </h3>
+            <h1>
+              You can also find the source code for this site at this link:
+              <a href="https://github.com/scrapdviz/scrapdviz">Visualization Source</a>.
+            </h1>
+            <h3>
+              ScrAPD is a project of Open Austin, a Code for America brigade. You can find more data about the
+              organization at this link: <a href="https://open-austin.org">Open Austin</a>.
+            </h3>
           </div>
-          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png" width='25%' />     
+          <img
+            src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Square_on_plane.svg/1024px-Square_on_plane.svg.png"
+            width="25%"
+          />
         </div>
       </div>
-
     </div>
   );
 };
-
 
 export default ScrapdDeveloperView;

--- a/components/scrapd-developers-view/component.js
+++ b/components/scrapd-developers-view/component.js
@@ -1,0 +1,17 @@
+import Proptypes from 'prop-types';
+import styled from '@emotion/styled';
+import dynamic from 'next/dynamic';
+
+const ScrapdDeveloperView = ({ fatalities }) => {
+  return (
+    <div>
+        <h3>Scrapd has documentation available at this link: <a href="https://docs.scrapd.org">Docs</a>.</h3>
+        <h3>Scrapd is open-source. You can find the scraping tool we use to retrieve data at this link: <a href="https://github.com/scrapd/scrapd">Scraper Source</a>.</h3>
+        <h1>You can also find the source code for this site at this link: <a href="https://github.com/scrapdviz/scrapdviz">Visualization Source</a>.</h1>
+        <h3>ScrAPD is a project of Open Austin, a Code for America brigade. You can find more data about the organization at this link: <a href="https://open-austin.org">Open Austin</a>.</h3>
+    </div>
+  );
+};
+
+
+export default ScrapdDeveloperView;

--- a/components/scrapd-developers-view/container.js
+++ b/components/scrapd-developers-view/container.js
@@ -1,0 +1,16 @@
+import Proptypes from 'prop-types';
+import ScrapdDeveloperView from './component';
+import { connect } from 'react-redux';
+
+const ScrapdDeveloperViewContainer = ({ developers }) => <ScrapdDeveloperView devData={developers} />;
+
+ScrapdDeveloperViewContainer.propTypes = {
+  developers: Proptypes.array
+};
+
+const mapStateToProps = state => {
+  const { developers } = state;
+  return { developers };
+};
+
+export default connect(mapStateToProps)(ScrapdDeveloperViewContainer);

--- a/components/scrapd-layout.js
+++ b/components/scrapd-layout.js
@@ -61,6 +61,11 @@ class ScrapdLayout extends React.Component {
                   <a>Archives</a>
                 </Link>{' '}
               </Menu.Item>
+              <Menu.Item key="developers">
+                <Link href="/developers">
+                  <a>For Developers</a>
+                </Link>{' '}
+              </Menu.Item>
             </Menu>
           </Header>
           <Layout>

--- a/pages/developers.js
+++ b/pages/developers.js
@@ -1,11 +1,10 @@
-import ScrapdControlsContainer from '../components/scrapd-controls/container';
 import ScrapdLayout from '../components/scrapd-layout';
 import ScrapdApdViewContainer from '../components/scrapd-developers-view/container';
 import { connect } from 'react-redux';
 
 const Developers = () => (
   <ScrapdLayout>
-      <ScrapdApdViewContainer />
+    <ScrapdApdViewContainer />
   </ScrapdLayout>
 );
 

--- a/pages/developers.js
+++ b/pages/developers.js
@@ -1,0 +1,12 @@
+import ScrapdControlsContainer from '../components/scrapd-controls/container';
+import ScrapdLayout from '../components/scrapd-layout';
+import ScrapdApdViewContainer from '../components/scrapd-developers-view/container';
+import { connect } from 'react-redux';
+
+const Developers = () => (
+  <ScrapdLayout>
+      <ScrapdApdViewContainer />
+  </ScrapdLayout>
+);
+
+export default connect()(Developers);


### PR DESCRIPTION
Types of changes
----------------
- Documentation

Description
-----------
Added a new page to point to the source. Screenshot:
![Screen Shot 2019-07-16 at 7 33 08 PM](https://user-images.githubusercontent.com/5067335/61338757-94b70700-a800-11e9-8760-479f280f6f5b.png)

Local testing performed - no logic in here, just a bit of HTML. 

VERY interested in feedback, this is only one way to get this information across and a simple page seemed like the most straightforward way to solve the problem.
We'll probably also need CSS at some point, a better layout of the text itself, and if we want it should be easy to get github stats (+ the latest release, etc) for the repositories themselves. 
I've also left the code in for the component to accept properties; I don't think it harms anything right now, and it may be useful in the future. 


Checklist
---------
-  [] I have updated the documentation accordingly
-  [] I have written unit tests

Addresses https://github.com/scrapd/scrapdviz/issues/131
